### PR TITLE
FIX: nRF Connect v2.3.0対応

### DIFF
--- a/boards/arm/scm-ltem1nrf_nrf9160/CMakeLists.txt
+++ b/boards/arm/scm-ltem1nrf_nrf9160/CMakeLists.txt
@@ -2,3 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+
+if(CONFIG_BOARD_SCM_LTEM1NRF_NRF9160_NS AND DEFINED CONFIG_BOOTLOADER_MCUBOOT)
+    set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/scm-ltem1nrf_pm_static.yml CACHE INTERNAL "")
+endif()

--- a/boards/arm/scm-ltem1nrf_nrf9160/Kconfig.defconfig
+++ b/boards/arm/scm-ltem1nrf_nrf9160/Kconfig.defconfig
@@ -1,4 +1,4 @@
-# nRF9160 DK NRF9160 board configuration
+# Sakura Internet SCM-LTEM1NRF board configuration
 
 # Copyright (c) 2018-2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_nrf9160_common.dts
+++ b/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_nrf9160_common.dts
@@ -6,7 +6,7 @@
 #include "scm-ltem1nrf_nrf9160_common-pinctrl.dtsi"
 
 / {
-	model = "Nordic nRF9160 DK NRF9160";
+	model = "Sakura Internet SCM-LTEM1NRF";
 	compatible = "nordic,nrf9160-dk-nrf9160";
 
 	chosen {
@@ -27,11 +27,11 @@
 		};
 		led2: led_2 {
 			gpios = <&gpio0 6 0>;
-			label = "Green LED 3";
+			label = "LED A";
 		};
 		led3: led_3 {
 			gpios = <&gpio0 7 0>;
-			label = "Green LED 4";
+			label = "LED B";
 		};
 	};
 
@@ -148,13 +148,13 @@
 		slot0_partition: partition@10000 {
 			label = "image-0";
 		};
-		slot0_ns_partition: partition@50000 {
+		slot0_ns_partition: partition@40000 {
 			label = "image-0-nonsecure";
 		};
 		slot1_partition: partition@80000 {
 			label = "image-1";
 		};
-		slot1_ns_partition: partition@c0000 {
+		slot1_ns_partition: partition@b0000 {
 			label = "image-1-nonsecure";
 		};
 		scratch_partition: partition@f0000 {

--- a/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_nrf9160_partition_conf.dts
+++ b/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_nrf9160_partition_conf.dts
@@ -22,19 +22,19 @@
  */
 
 &slot0_partition {
-	reg = <0x00010000 0x40000>;
+	reg = <0x00010000 0x30000>;
 };
 
 &slot0_ns_partition {
-	reg = <0x00050000 0x30000>;
+	reg = <0x00040000 0x40000>;
 };
 
 &slot1_partition {
-	reg = <0x00080000 0x40000>;
+	reg = <0x00080000 0x30000>;
 };
 
 &slot1_ns_partition {
-	reg = <0x000c0000 0x30000>;
+	reg = <0x000b0000 0x40000>;
 };
 
 /* Default SRAM planning when building for nRF9160 with

--- a/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_pm_static.yml
+++ b/boards/arm/scm-ltem1nrf_nrf9160/scm-ltem1nrf_pm_static.yml
@@ -1,0 +1,56 @@
+app: {address: 0x18000, size: 0x5b000}
+mcuboot:
+  address: 0x0
+  placement:
+    before: [mcuboot_primary]
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  placement:
+    align: {start: 0x1000}
+    before: [mcuboot_primary_app]
+  size: 0x200
+mcuboot_primary:
+  address: 0xc000
+  size: 0x69000
+  span: [tfm, mcuboot_pad, app]
+mcuboot_primary_app:
+  address: 0xc200
+  size: 0x68e00
+  span: [app, tfm]
+mcuboot_scratch:
+  address: 0xde000
+  placement:
+    after: [app]
+    align: {start: 0x1000}
+  size: 0x1e000
+mcuboot_secondary:
+  address: 0x75000
+  placement:
+    after: [mcuboot_primary]
+    align: {start: 0x1000}
+  share_size: [mcuboot_primary]
+  size: 0x69000
+EMPTY_0:
+  address: 0xfc000
+  size: 0x2000
+settings_storage:
+  address: 0xfe000
+  placement:
+    after: [mcuboot_scratch]
+  size: 0x2000
+nonsecure_storage:
+  address: 0xfe000
+  size: 0x2000
+  span: [settings_storage]
+tfm_secure:
+  address: 0xc000
+  size: 0xc000
+  span: [mcuboot_pad, tfm]
+tfm_nonsecure:
+  address: 0x18000
+  size: 0x5b000
+  span: [app]
+tfm:
+  address: 0xc200
+  size: 0xbe00

--- a/boards/thingy91_nrf9160_ns.overlay
+++ b/boards/thingy91_nrf9160_ns.overlay
@@ -1,7 +1,0 @@
-/ {
-	aliases {
-		led1 = &sense_red_led;
-		led2 = &sense_green_led;
-		led3 = &sense_blue_led;
-	};
-};

--- a/src/main.c
+++ b/src/main.c
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/led.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/led.h>
 
-#include <drivers/flash.h>
-
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 /* The devicetree node identifier for the "led0" alias. */


### PR DESCRIPTION
- ボード定義にPartitionManagerの設定ファイル&設定ファイル参照を追加
- ZephyrOS関連のヘッダファイルのパス変更に対応